### PR TITLE
Add StackBackButton component to AddPropertyManagement

### DIFF
--- a/src/navigation/AddProperty/AddPropertyManagement/AddPropertyManagement.tsx
+++ b/src/navigation/AddProperty/AddPropertyManagement/AddPropertyManagement.tsx
@@ -10,6 +10,7 @@ import FormikOwnerSelect from '../../../components/molecules/FormikOwnerSelect'
 import FormikPropertyTypeSelect from '../../../components/molecules/FormikPropertyTypeSelect'
 import FormikYearSelect from '../../../components/molecules/FormikYearSelect'
 import FormikStatus from '../../../components/molecules/FormikStatus'
+import StackBackButton from '../../../components/molecules/StackBackButton'
 
 export default function AddPropertyManagement({
   save,
@@ -22,6 +23,9 @@ export default function AddPropertyManagement({
     <SafeAreaView>
       <ScrollView keyboardShouldPersistTaps='always'>
         <View className='w-full items-center'>
+          <View className='w-11/12 flex justify-center'>
+            <StackBackButton />
+          </View>
           <Text className='text-2xl font-bold mb-3'>Ajouter une propriété</Text>
           <FormikField
             name='name'


### PR DESCRIPTION
This pull request adds the StackBackButton component to the AddPropertyManagement screen. The StackBackButton component allows users to navigate back to the previous screen in the application.